### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+*.DS_Store


### PR DESCRIPTION
This commit adds a `.gitignore` to accommodate for `vim(1)` and Mac OS X `.DS_Store` files.